### PR TITLE
Chore: Add specifier to decode date strings using iso 8601 by default

### DIFF
--- a/graphql-ios.xcodeproj/project.pbxproj
+++ b/graphql-ios.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3088C3F363EB74FC188038E2 /* Pods_graphql_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD9BF25D3A418576D8C9D23E /* Pods_graphql_ios.framework */; };
+		8851E15A22B9820D00B8A2C1 /* GraphQLJSONDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8851E15922B9820D00B8A2C1 /* GraphQLJSONDecoderTests.swift */; };
 		A508FE3D22B036410057838A /* GraphQLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A508FE3C22B036410057838A /* GraphQLNode.swift */; };
 		A508FE5622B039C40057838A /* GraphQLNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A508FE5522B039C40057838A /* GraphQLNodeTests.swift */; };
 		A52B129122A6BCD100EAA97E /* GraphQLJSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52B129022A6BCD100EAA97E /* GraphQLJSONDecoder.swift */; };
@@ -66,6 +67,7 @@
 		34572D952D9B40B9BC9F3F60 /* Pods-graphql-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-graphql-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-graphql-ios/Pods-graphql-ios.release.xcconfig"; sourceTree = "<group>"; };
 		5569D19D30C38659AFBEBD3F /* Pods_graphql_iosTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_graphql_iosTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8048760F790EB4649BB286AF /* Pods_graphql_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_graphql_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8851E15922B9820D00B8A2C1 /* GraphQLJSONDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphQLJSONDecoderTests.swift; sourceTree = "<group>"; };
 		8CAC723269A642BB899C8B86 /* Pods-graphql-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-graphql-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-graphql-ios/Pods-graphql-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		A508FE3C22B036410057838A /* GraphQLNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLNode.swift; sourceTree = "<group>"; };
 		A508FE5522B039C40057838A /* GraphQLNodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GraphQLNodeTests.swift; sourceTree = "<group>"; };
@@ -147,6 +149,14 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		8851E15822B981F900B8A2C1 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				8851E15922B9820D00B8A2C1 /* GraphQLJSONDecoderTests.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		A52B128F22A6BCC000EAA97E /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -214,6 +224,7 @@
 		A5B6775222A5ACF700708DD3 /* graphql-iosTests */ = {
 			isa = PBXGroup;
 			children = (
+				8851E15822B981F900B8A2C1 /* Utils */,
 				A5D2EC6822AEE6A300626D76 /* TestHelpers */,
 				A5BFD29022AEA31900B37555 /* Models */,
 				A5D2EC6322AEE5F700626D76 /* Service */,
@@ -528,6 +539,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8851E15A22B9820D00B8A2C1 /* GraphQLJSONDecoderTests.swift in Sources */,
 				A5D2EC7522AEF4E500626D76 /* GraphQLValidatingTests.swift in Sources */,
 				A5BFD29222AEA33500B37555 /* GraphQLRemoteErrorTests.swift in Sources */,
 				A5D2EC6722AEE69B00626D76 /* StubManager.swift in Sources */,

--- a/graphql-ios/Utils/GraphQLJSONDecoder.swift
+++ b/graphql-ios/Utils/GraphQLJSONDecoder.swift
@@ -12,6 +12,7 @@ internal class GraphQLJSONDecoder: JSONDecoder {
     override init() {
         super.init()
         self.keyDecodingStrategy = .convertFromSnakeCase
+        self.dateDecodingStrategy = .iso8601
     }
 
     func decodeObjectNotation<T>(_ type: T.Type, from obj: Any) throws -> T where T: Decodable {

--- a/graphql-ios/Utils/GraphQLJSONDecoder.swift
+++ b/graphql-ios/Utils/GraphQLJSONDecoder.swift
@@ -8,11 +8,28 @@
 
 internal class GraphQLJSONDecoder: JSONDecoder {
     var logger: GraphQLLogging?
+    private let iso8601Formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        return formatter
+    }()
 
     override init() {
         super.init()
         self.keyDecodingStrategy = .convertFromSnakeCase
-        self.dateDecodingStrategy = .iso8601
+        if #available(iOS 10.0, *) {
+            self.dateDecodingStrategy = .iso8601
+        } else {
+            self.dateDecodingStrategy = .custom { [iso8601Formatter] decoder -> Date in
+                let container = try decoder.singleValueContainer()
+                let dateString = try container.decode(String.self)
+                guard let date = iso8601Formatter.date(from: dateString) else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Couldn't convert the given string to a date")
+                }
+                return date
+            }
+        }
     }
 
     func decodeObjectNotation<T>(_ type: T.Type, from obj: Any) throws -> T where T: Decodable {

--- a/graphql-iosTests/Utils/GraphQLJSONDecoderTests.swift
+++ b/graphql-iosTests/Utils/GraphQLJSONDecoderTests.swift
@@ -1,0 +1,39 @@
+//
+//  GraphQLJSONDecoderTests.swift
+//  graphql-iosTests
+//
+//  Created by Blake Macnair on 6/18/19.
+//  Copyright © 2019 Fooda. All rights reserved.
+//
+
+import XCTest
+@testable import graphql_ios
+
+final class GraphQLJSONDecoderTests: XCTestCase {
+    func testDecodeDateFromString() {
+        let jsonDecoder = GraphQLJSONDecoder()
+        let isoString = """
+                        ["2014-06-13T12:00:00+00:00"]
+                        """
+
+        guard let data = isoString.data(using: .unicode),
+            let dates = try? jsonDecoder.decode([Date].self, from: data),
+            let date = dates.first else {
+            XCTFail("Couldn't convert string to data or date object.")
+                return
+        }
+
+        let componentSet: Set<Calendar.Component> = Set([.timeZone, .year, .month, .day, .hour, .minute, .second])
+        let components = Calendar.current.dateComponents(componentSet, from: date)
+        let timeOffset: Int = TimeZone.current.secondsFromGMT() / 60 / 60
+        let expectedComponents: DateComponents = .init(timeZone: .current,
+                                                       year: 2014,
+                                                       month: 6,
+                                                       day: 13,
+                                                       hour: 12 + timeOffset,
+                                                       minute: 0,
+                                                       second: 0)
+
+        XCTAssertEqual(components, expectedComponents)
+    }
+}


### PR DESCRIPTION
### Description
Not much more than the title. We just expect ISO 8601 date strings as a standard from our API, so we can set that as the default decoding strategy for our GraphQLJSONDecoder.